### PR TITLE
Android lifecycle

### DIFF
--- a/app/dependencies.gradle
+++ b/app/dependencies.gradle
@@ -1,10 +1,11 @@
 ext {
     support_version = '27.0.0'
-    dagger_version = '2.11'
+    dagger_version = '2.12'
     retrofit_ver = '2.2.0'
     okhttp_ver = '3.7.0'
     rxlifecycle_ver = '2.1.0'
     binding_collection_adapter_ver = '2.2.0'
+    cached_field_ver = '1.7.0-RC3'
     cappuccino_ver = '0.9.1'
 }
 
@@ -19,8 +20,8 @@ dependencies {
     implementation "com.android.support:recyclerview-v7:$support_version"
     implementation "com.android.support:palette-v7:$support_version"
     implementation "com.android.support:design:$support_version"
-    implementation 'com.byoutline.secretsauce:secretsaucekt:0.6.0-beta3'
-    implementation "com.byoutline.observablecachedfield:observablecachedfield:1.7.0-RC3"
+    implementation 'com.byoutline.secretsauce:secretsaucekt:0.6.0-beta6'
+    implementation "com.byoutline.observablecachedfield:observablecachedfield:$cached_field_ver"
     implementation 'com.byoutline.androidstubserver:stubserver:2.0.0-beta2'
     implementation "com.squareup.retrofit2:retrofit:$retrofit_ver"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_ver"
@@ -32,14 +33,14 @@ dependencies {
     implementation 'nz.bradcampbell:paperparcel-kotlin:2.0.1'
     implementation 'io.reactivex.rxjava2:rxjava:2.1.3'
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
-    implementation "com.trello.rxlifecycle2:rxlifecycle:$rxlifecycle_ver"
-    implementation "com.trello.rxlifecycle2:rxlifecycle-components:$rxlifecycle_ver"
-    implementation "com.trello.rxlifecycle2:rxlifecycle-kotlin:$rxlifecycle_ver"
+    implementation "android.arch.lifecycle:extensions:1.0.0"
     kapt 'nz.bradcampbell:paperparcel-compiler:2.0.1'
     kapt "com.android.databinding:compiler:$buildscript_tools_ver"
     // For dagger 2
     implementation "com.google.dagger:dagger:$dagger_version"
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
+    implementation 'com.google.dagger:dagger-android-support:2.12'
+    kapt 'com.google.dagger:dagger-android-processor:2.12'
 
     implementation 'joda-time:joda-time:2.9.9'
     implementation 'org.joda:joda-convert:1.7'
@@ -94,7 +95,7 @@ dependencies {
     }
     androidTestImplementation 'com.squareup.spoon:spoon-client:1.7.1'
     androidTestImplementation 'com.byoutline.cachedfield:idlingresource:1.0.0'
-    androidTestImplementation "com.byoutline.observablecachedfield:observablecachedfield:1.7.0-RC3"
+    androidTestImplementation "com.byoutline.observablecachedfield:observablecachedfield:$cached_field_ver"
 }
 
 // AS does not want to run application with play button without resolution strategy

--- a/app/src/androidTest/java/com/byoutline/kickmaterial/espressohelpers/DaggerRules.kt
+++ b/app/src/androidTest/java/com/byoutline/kickmaterial/espressohelpers/DaggerRules.kt
@@ -11,7 +11,7 @@ import android.support.test.rule.ActivityTestRule
 import com.byoutline.cachedfield.CachedFieldWithArg
 import com.byoutline.cachedfield.utils.CachedFieldIdlingResource
 import com.byoutline.kickmaterial.KickMaterialApp
-import com.byoutline.kickmaterial.dagger.GlobalComponent
+import com.byoutline.kickmaterial.dagger.AppComponent
 import com.byoutline.kickmaterial.features.projectlist.MainActivity
 import com.squareup.spoon.Spoon
 import org.junit.rules.ExternalResource
@@ -20,7 +20,7 @@ import org.junit.runners.model.Statement
 import kotlin.reflect.KClass
 
 /**
- * Methods returning custom [ActivityTestRule]s that set test [GlobalComponent].
+ * Methods returning custom [ActivityTestRule]s that set test [AppComponent].
 
  * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com>
  */
@@ -36,7 +36,7 @@ object DaggerRules {
             = CachedFieldIdlingResourceRule(KickMaterialApp.component.discoverField)
 
     private fun <ACTIVITY : Activity> getActivityRule(
-            mainComponentProv: (KickMaterialApp) -> GlobalComponent,
+            mainComponentProv: (KickMaterialApp) -> AppComponent,
             clazz: KClass<ACTIVITY>
     ): ActivityTestRule<ACTIVITY> {
         val mainHandler = Handler(Looper.getMainLooper())

--- a/app/src/androidTest/java/com/byoutline/kickmaterial/espressohelpers/TestComponents.kt
+++ b/app/src/androidTest/java/com/byoutline/kickmaterial/espressohelpers/TestComponents.kt
@@ -3,13 +3,13 @@ package com.byoutline.kickmaterial.espressohelpers
 import android.content.SharedPreferences
 import android.preference.PreferenceManager
 import com.byoutline.kickmaterial.KickMaterialApp
-import com.byoutline.kickmaterial.dagger.DaggerGlobalComponent
-import com.byoutline.kickmaterial.dagger.GlobalComponent
-import com.byoutline.kickmaterial.dagger.GlobalModule
+import com.byoutline.kickmaterial.dagger.AppComponent
+import com.byoutline.kickmaterial.dagger.AppModule
+import com.byoutline.kickmaterial.dagger.DaggerAppComponent
 import com.byoutline.kickmaterial.features.projectlist.ProjectsListFragment
 
 /**
- * Methods returning test [GlobalComponent]s with changed injects.
+ * Methods returning test [AppComponent]s with changed injects.
  *
  * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com>
  */
@@ -19,9 +19,9 @@ internal object TestComponents {
 
     fun getNextRunComponent(app: KickMaterialApp) = getComponent(app, getNextRunSharedPrefs(app))
 
-    private fun getComponent(app: KickMaterialApp, sharedPrefs: SharedPreferences): GlobalComponent {
-        return DaggerGlobalComponent.builder()
-                .globalModule(object : GlobalModule(app) {
+    private fun getComponent(app: KickMaterialApp, sharedPrefs: SharedPreferences): AppComponent {
+        return DaggerAppComponent.builder()
+                .appModule(object : AppModule(app) {
                     override fun provideSharedPrefs() = sharedPrefs
 
                     override fun provideAnimationDurationMultiplier() = 0

--- a/app/src/main/java/com/byoutline/kickmaterial/KickMaterialApp.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/KickMaterialApp.kt
@@ -1,21 +1,35 @@
 package com.byoutline.kickmaterial
 
+import android.app.Activity
 import android.app.Application
+import android.arch.lifecycle.ViewModelProvider
+import android.content.Context
 import android.support.annotation.VisibleForTesting
 import com.byoutline.androidstubserver.AndroidStubServer
-import com.byoutline.kickmaterial.dagger.DaggerGlobalComponent
-import com.byoutline.kickmaterial.dagger.GlobalComponent
-import com.byoutline.kickmaterial.dagger.GlobalModule
+import com.byoutline.kickmaterial.dagger.AppComponent
+import com.byoutline.kickmaterial.dagger.AppModule
+import com.byoutline.kickmaterial.dagger.DaggerAppComponent
 import com.byoutline.mockserver.NetworkType
 import com.byoutline.observablecachedfield.util.RetrofitHelper
-import com.byoutline.secretsauce.Settings
+import com.byoutline.secretsauce.SecretSauceSettings
+import com.byoutline.secretsauce.di.AppInjector
 import com.byoutline.secretsauce.utils.showToast
+import dagger.android.DispatchingAndroidInjector
+import dagger.android.HasActivityInjector
 import timber.log.Timber
+import javax.inject.Inject
 
 /**
  * @author Pawel Karczewski <pawel.karczewski at byoutline.com> on 2015-01-03
  */
-class KickMaterialApp : Application() {
+open class KickMaterialApp : Application(), HasActivityInjector {
+
+    @Inject
+    open lateinit var dispatchingActivityInjector: DispatchingAndroidInjector<Activity>
+    @Inject
+    open lateinit var viewModelFactory: ViewModelProvider.Factory
+
+    override fun activityInjector() = dispatchingActivityInjector
 
     override fun onCreate() {
         super.onCreate()
@@ -25,28 +39,35 @@ class KickMaterialApp : Application() {
         AndroidStubServer.start(this, NetworkType.UMTS)
         RetrofitHelper.setMsgDisplayer { msg -> this.showToast(msg, true) }
 
-        resetComponents()
+        initDagger()
     }
 
     @VisibleForTesting
-    @Synchronized
-    fun setComponents(mainComponent: GlobalComponent) {
-        component = mainComponent
-        Settings.set(debug = BuildConfig.DEBUG, containerViewId = R.id.container)
+    open fun initDagger() {
+        setComponents(createGlobalComponent())
     }
 
-    private fun resetComponents() {
-        val mainComponent = createGlobalComponent()
-        setComponents(mainComponent)
+    @VisibleForTesting
+    open fun setComponents(appComponent: AppComponent) {
+        component = appComponent
+        component.inject(this)
+        AppInjector.init(this)
+        SecretSauceSettings.set(debug = BuildConfig.DEBUG,
+                containerViewId = R.id.container,
+                bindingViewModelId = BR.viewModel,
+                viewModelFactoryProvider = ::getViewModelFactory)
     }
 
-    private fun createGlobalComponent(): GlobalComponent {
-        return DaggerGlobalComponent.builder()
-                .globalModule(GlobalModule(this))
+    private fun createGlobalComponent(): AppComponent {
+        return DaggerAppComponent.builder()
+                .appModule(AppModule(this))
                 .build()
     }
 
     companion object {
-        lateinit var component: GlobalComponent
+        lateinit var component: AppComponent
     }
 }
+
+private fun getViewModelFactory(ctx: Context): ViewModelProvider.Factory
+    = (ctx.applicationContext as KickMaterialApp).viewModelFactory

--- a/app/src/main/java/com/byoutline/kickmaterial/api/KickMaterialRequestInterceptor.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/api/KickMaterialRequestInterceptor.kt
@@ -1,15 +1,15 @@
 package com.byoutline.kickmaterial.api
 
-import com.byoutline.kickmaterial.dagger.GlobalScope
 import okhttp3.Interceptor
 import okhttp3.Response
 import java.io.IOException
 import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com> on 05.05.14.
  */
-@GlobalScope
+@Singleton
 class KickMaterialRequestInterceptor
 @Inject constructor() : Interceptor {
 

--- a/app/src/main/java/com/byoutline/kickmaterial/dagger/AndroidModules.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/dagger/AndroidModules.kt
@@ -1,0 +1,76 @@
+package com.byoutline.kickmaterial.dagger
+
+import android.arch.lifecycle.ViewModel
+import android.arch.lifecycle.ViewModelProvider
+import android.content.SharedPreferences
+import com.byoutline.kickmaterial.features.projectdetails.ProjectDetailsActivity
+import com.byoutline.kickmaterial.features.projectlist.MainActivity
+import com.byoutline.kickmaterial.features.projectlist.ProjectListViewModel
+import com.byoutline.kickmaterial.features.projectlist.ProjectsListFragment
+import com.byoutline.kickmaterial.features.rewardlist.RewardListViewModel
+import com.byoutline.kickmaterial.features.rewardlist.RewardsListActivity
+import com.byoutline.kickmaterial.features.search.SearchListFragment
+import com.byoutline.kickmaterial.features.search.SearchViewModel
+import com.byoutline.kickmaterial.features.selectcategory.CategoriesListActivity
+import com.byoutline.kickmaterial.features.selectcategory.CategoriesListViewModel
+import com.byoutline.kickmaterial.model.DiscoverQuery
+import com.byoutline.kickmaterial.model.DiscoverResponse
+import com.byoutline.observablecachedfield.ObservableCachedFieldWithArg
+import com.byoutline.secretsauce.di.ViewModelFactory
+import com.byoutline.secretsauce.di.ViewModelKey
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.android.ContributesAndroidInjector
+import dagger.multibindings.IntoMap
+import javax.inject.Singleton
+
+@Module
+abstract class MainActivityModule {
+    @ContributesAndroidInjector(modules = arrayOf(ProjectsListFragmentsModule::class))
+    abstract fun mainActivity(): MainActivity
+
+    @ContributesAndroidInjector abstract fun projectDetailsActivity(): ProjectDetailsActivity
+    @ContributesAndroidInjector abstract fun rewardsListActivity(): RewardsListActivity
+    @ContributesAndroidInjector abstract fun categoriesListActivity(): CategoriesListActivity
+}
+
+@Module
+abstract class ProjectsListFragmentsModule {
+    @ContributesAndroidInjector abstract fun projectsListFragment(): ProjectsListFragment
+    @ContributesAndroidInjector abstract fun searchListFragment(): SearchListFragment
+}
+
+@Module
+abstract class ViewModelMapModule {
+    @Binds @Singleton
+    abstract fun viewModelFactory(factory: ViewModelFactory): ViewModelProvider.Factory
+}
+
+@Module
+class ViewModelProvidersModule {
+
+    @Provides @IntoMap
+    @ViewModelKey(ProjectListViewModel::class)
+    fun projectListViewModel(sharedPrefs: SharedPreferences,
+                             discoverField: ObservableCachedFieldWithArg<DiscoverResponse, DiscoverQuery>): ViewModel {
+        // show header on first launch
+        val showHeader = sharedPrefs.getBoolean(ProjectsListFragment.PREFS_SHOW_HEADER, true)
+        sharedPrefs.edit().putBoolean(ProjectsListFragment.PREFS_SHOW_HEADER, false).apply()
+        return ProjectListViewModel(showHeader, discoverField)
+    }
+
+    @Provides @IntoMap
+    @ViewModelKey(SearchViewModel::class)
+    fun searchViewModel(discoverField: ObservableCachedFieldWithArg<DiscoverResponse, DiscoverQuery>): ViewModel
+            = SearchViewModel(discoverField)
+
+    @Provides @IntoMap
+    @ViewModelKey(RewardListViewModel::class)
+    fun rewardListViewModel(): ViewModel = RewardListViewModel()
+
+    @Provides @IntoMap
+    @ViewModelKey(CategoriesListViewModel::class)
+    fun categoriesListViewModel(discoverField: ObservableCachedFieldWithArg<DiscoverResponse, DiscoverQuery>): ViewModel
+            = CategoriesListViewModel(discoverField)
+}

--- a/app/src/main/java/com/byoutline/kickmaterial/dagger/AppComponent.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/dagger/AppComponent.kt
@@ -2,26 +2,25 @@ package com.byoutline.kickmaterial.dagger
 
 import com.byoutline.kickmaterial.KickMaterialApp
 import com.byoutline.kickmaterial.features.projectdetails.ProjectDetailsActivity
-import com.byoutline.kickmaterial.features.projectlist.ProjectsListFragment
-import com.byoutline.kickmaterial.features.rewardlist.RewardsListActivity
-import com.byoutline.kickmaterial.features.search.SearchListFragment
-import com.byoutline.kickmaterial.features.selectcategory.CategoriesListActivity
 import com.byoutline.kickmaterial.model.DiscoverQuery
 import com.byoutline.kickmaterial.model.DiscoverResponse
 import com.byoutline.observablecachedfield.ObservableCachedFieldWithArg
 import dagger.Component
+import javax.inject.Singleton
 
 /**
  * Created by Sebastian Kacprzak <sebastian.kacprzak at byoutline.com> on 27.03.15.
  */
-@GlobalScope
-@Component(modules = arrayOf(GlobalModule::class))
-interface GlobalComponent {
-    fun inject(fragment: CategoriesListActivity)
-    fun inject(fragment: SearchListFragment)
-    fun inject(fragment: ProjectsListFragment)
+@Singleton
+@Component(modules = arrayOf(
+        AppModule::class,
+        MainActivityModule::class,
+        ViewModelMapModule::class,
+        ViewModelProvidersModule::class
+))
+interface AppComponent {
     fun inject(activity: ProjectDetailsActivity)
-    fun inject(rewardsListActivity: RewardsListActivity)
+    fun inject(app: KickMaterialApp)
 
     val app: KickMaterialApp
     val discoverField: ObservableCachedFieldWithArg<DiscoverResponse, DiscoverQuery>

--- a/app/src/main/java/com/byoutline/kickmaterial/dagger/Scopes.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/dagger/Scopes.kt
@@ -1,8 +1,0 @@
-package com.byoutline.kickmaterial.dagger
-
-import javax.inject.Scope
-
-@Scope
-@Retention(AnnotationRetention.RUNTIME)
-annotation class GlobalScope
-

--- a/app/src/main/java/com/byoutline/kickmaterial/features/projectdetails/ProjectDetailsActivity.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/features/projectdetails/ProjectDetailsActivity.kt
@@ -24,6 +24,7 @@ import com.byoutline.kickmaterial.utils.LUtils
 import com.byoutline.secretsauce.activities.WebViewActivityV7
 import com.byoutline.secretsauce.activities.WebViewFlickrActivity
 import com.byoutline.secretsauce.utils.ViewUtils
+import com.byoutline.secretsauce.utils.showToast
 import com.squareup.picasso.Picasso
 import javax.inject.Inject
 
@@ -113,9 +114,9 @@ class ProjectDetailsActivity : KickMaterialBaseActivity(), DelayedTransitionActi
     }
 
     private fun showRewardList() {
-        transitionHelper.executeIfCachedProjectDetailsAreAvailable(R.string.retry_getting_project_rewards) { details ->
+        transitionHelper.executeIfCachedProjectDetailsAreAvailable({ details ->
             RewardsListActivity.launch(this, details, binding.playVideoBtn)
-        }
+        }, displayErrorAction = { showToast(R.string.retry_getting_project_details) })
     }
 
     public override fun onResume() {
@@ -143,9 +144,9 @@ class ProjectDetailsActivity : KickMaterialBaseActivity(), DelayedTransitionActi
                 ViewUtils.showView(readMoreBtn, false)
             }
             playVideoBtn.setOnClickListener {
-                transitionHelper.executeIfCachedProjectDetailsAreAvailable(R.string.retry_getting_project_details) { details ->
+                transitionHelper.executeIfCachedProjectDetailsAreAvailable({ details ->
                     VideoActivity.showActivity(this@ProjectDetailsActivity, details)
-                }
+                }, displayErrorAction = { showToast(R.string.retry_getting_project_details) })
             }
             listOf(projectAuthorNameLabelTv as View, authorPhotoIv, projectAuthorNameTv).forEach {
                 it.setOnClickListener { showWebView(transitionHelper.project.authorUrl, Intent(this@ProjectDetailsActivity, WebViewFlickrActivity::class.java)) }

--- a/app/src/main/java/com/byoutline/kickmaterial/features/projectdetails/ProjectDetailsTransitionHelper.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/features/projectdetails/ProjectDetailsTransitionHelper.kt
@@ -5,18 +5,14 @@ import android.graphics.drawable.BitmapDrawable
 import android.support.annotation.ColorInt
 import android.support.annotation.StringRes
 import android.widget.ImageView
-import com.byoutline.kickmaterial.KickMaterialApp
 import com.byoutline.kickmaterial.R
 import com.byoutline.kickmaterial.model.Project
 import com.byoutline.kickmaterial.model.ProjectDetails
 import com.byoutline.kickmaterial.model.ProjectIdAndSignature
 import com.byoutline.kickmaterial.transitions.PaletteAndAplaTransformation
 import com.byoutline.observablecachedfield.ObservableCachedFieldWithArg
-import com.byoutline.secretsauce.utils.showToast
 import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
-import com.trello.rxlifecycle2.LifecycleProvider
-import com.trello.rxlifecycle2.android.ActivityEvent
 import dagger.Reusable
 import javax.inject.Inject
 
@@ -44,7 +40,7 @@ class ProjectDetailsTransitionHelperFactory
 }
 
 
-interface DelayedTransitionActivity : LifecycleProvider<ActivityEvent> {
+interface DelayedTransitionActivity {
     fun startPostponedEnterTrans()
     fun setDetailsContainerBgColor(@ColorInt color: Int)
 }
@@ -60,10 +56,10 @@ class ProjectDetailsTransitionHelper(val projectDetailsField: ObservableCachedFi
     val projectBackingProgressTxtId: Int = if (project.isFunded) R.string.funded else R.string.backing_in_progress
     internal val videoBtnAnimator = VideoAlphaAnimator()
 
-    fun executeIfCachedProjectDetailsAreAvailable(@StringRes errorResId: Int, action: (ProjectDetails) -> Unit) {
+    fun executeIfCachedProjectDetailsAreAvailable(action: (ProjectDetails) -> Any, displayErrorAction: ()-> Any) {
         val details = projectDetailsField.observable().get()
         if (details == null) {
-            KickMaterialApp.component.app.showToast(errorResId)
+            displayErrorAction()
             postProjectDetails()
         } else {
             action(details)

--- a/app/src/main/java/com/byoutline/kickmaterial/features/projectlist/MainActivity.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/features/projectlist/MainActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.TargetApi
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.support.v4.app.Fragment
 import android.view.Menu
 import com.byoutline.kickmaterial.R
 import com.byoutline.kickmaterial.features.selectcategory.ARG_CATEGORY
@@ -12,12 +13,19 @@ import com.byoutline.kickmaterial.features.selectcategory.DataManager
 import com.byoutline.kickmaterial.model.Category
 import com.byoutline.kickmaterial.utils.KickMaterialBaseActivity
 import com.byoutline.secretsauce.activities.showFragment
+import dagger.android.AndroidInjector
+import dagger.android.DispatchingAndroidInjector
+import dagger.android.support.HasSupportFragmentInjector
+import javax.inject.Inject
 
 
 /**
  * @author Pawel Karczewski <pawel.karczewski at byoutline.com> on 2015-01-03
  */
-class MainActivity : KickMaterialBaseActivity() {
+class MainActivity : KickMaterialBaseActivity(), HasSupportFragmentInjector {
+    @Inject
+    lateinit var dispatchingFragmentInjector: DispatchingAndroidInjector<Fragment>
+    override fun supportFragmentInjector(): AndroidInjector<Fragment> = dispatchingFragmentInjector
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/byoutline/kickmaterial/features/projectlist/ProjectsListFragment.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/features/projectlist/ProjectsListFragment.kt
@@ -7,7 +7,6 @@ import android.support.v7.widget.GridLayoutManager
 import android.view.*
 import com.byoutline.cachedfield.FieldState
 import com.byoutline.cachedfield.FieldStateListener
-import com.byoutline.kickmaterial.KickMaterialApp
 import com.byoutline.kickmaterial.R
 import com.byoutline.kickmaterial.databinding.FragmentProjectsBinding
 import com.byoutline.kickmaterial.features.projectdetails.startProjectDetailsActivity
@@ -22,20 +21,21 @@ import com.byoutline.kickmaterial.utils.KickMaterialFragment
 import com.byoutline.kickmaterial.utils.LUtils
 import com.byoutline.kickmaterial.views.EndlessRecyclerView
 import com.byoutline.secretsauce.activities.showFragment
+import com.byoutline.secretsauce.di.Injectable
+import com.byoutline.secretsauce.di.inflateAndSetViewModel
+import com.byoutline.secretsauce.di.lazyViewModelWithAutoLifecycle
 import timber.log.Timber
-import javax.inject.Inject
+
 
 /**
  * @author Pawel Karczewski <pawel.karczewski at byoutline.com> on 2015-01-03
  */
-class ProjectsListFragment : KickMaterialFragment(), ProjectClickListener, FieldStateListener, EndlessRecyclerView.EndlessScrollListener {
+class ProjectsListFragment : KickMaterialFragment(), Injectable, ProjectClickListener, FieldStateListener, EndlessRecyclerView.EndlessScrollListener {
 
-    @Inject
-    lateinit var viewModel: ProjectListViewModel
-
+    private val viewModel by lazyViewModelWithAutoLifecycle(this, ProjectListViewModel::class)
+    lateinit var binding: FragmentProjectsBinding
 
     private lateinit var category: Category
-    private lateinit var binding: FragmentProjectsBinding
     /**
      * Endless scroll variables *
      */
@@ -43,10 +43,7 @@ class ProjectsListFragment : KickMaterialFragment(), ProjectClickListener, Field
     private lateinit var scrollListener: ProjectsListScrollListener
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val binding = FragmentProjectsBinding.inflate(inflater, container, false)
-        this.binding = binding
-        KickMaterialApp.component.inject(this)
-        binding.viewModel = viewModel
+        binding = inflateAndSetViewModel(inflater, container, R.layout.fragment_projects, viewModel)
 
         hostActivity?.enableToolbarAutoHide(binding.projectRecyclerView)
 
@@ -94,8 +91,6 @@ class ProjectsListFragment : KickMaterialFragment(), ProjectClickListener, Field
     override fun onResume() {
         super.onResume()
         restoreDefaultScreenLook()
-        Timber.d("items will be attached")
-        viewModel.attachViewUntilPause(this)
         viewModel.discoverField.addStateListener(this)
         Timber.d("items will be refreshed ${viewModel.category}")
         viewModel.loadCurrentPage()

--- a/app/src/main/java/com/byoutline/kickmaterial/features/rewardlist/RewardListViewModel.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/features/rewardlist/RewardListViewModel.kt
@@ -1,5 +1,6 @@
 package com.byoutline.kickmaterial.features.rewardlist
 
+import android.arch.lifecycle.ViewModel
 import android.databinding.ObservableArrayList
 import android.graphics.Color
 import android.support.annotation.ColorInt
@@ -7,7 +8,6 @@ import android.support.v4.content.ContextCompat
 import com.byoutline.kickmaterial.BR
 import com.byoutline.kickmaterial.KickMaterialApp
 import com.byoutline.kickmaterial.R
-import com.byoutline.kickmaterial.dagger.GlobalScope
 import com.byoutline.kickmaterial.model.Reward
 import com.byoutline.kickmaterial.model.RewardItem
 import com.byoutline.secretsauce.utils.showDebugToast
@@ -16,11 +16,8 @@ import me.tatarka.bindingcollectionadapter2.itembindings.OnItemBindClass
 import paperparcel.PaperParcel
 import paperparcel.PaperParcelable
 import java.util.*
-import javax.inject.Inject
 
-@GlobalScope
-class RewardListViewModel
-@Inject constructor() {
+class RewardListViewModel : ViewModel() {
     val items = ObservableArrayList<RewardItem>()
     val itemBinding: ItemBinding<RewardItem>
     @ColorInt

--- a/app/src/main/java/com/byoutline/kickmaterial/features/rewardlist/RewardsListActivity.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/features/rewardlist/RewardsListActivity.kt
@@ -14,7 +14,6 @@ import android.support.v4.app.ActivityCompat
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.RecyclerView
 import android.view.View
-import com.byoutline.kickmaterial.KickMaterialApp
 import com.byoutline.kickmaterial.R
 import com.byoutline.kickmaterial.databinding.FragmentRewardsListBinding
 import com.byoutline.kickmaterial.features.selectcategory.CategoriesListSeparator
@@ -22,24 +21,22 @@ import com.byoutline.kickmaterial.model.ProjectDetails
 import com.byoutline.kickmaterial.utils.ContainerTranslationScrollListener
 import com.byoutline.kickmaterial.utils.KickMaterialBaseActivity
 import com.byoutline.kickmaterial.utils.LUtils
+import com.byoutline.secretsauce.di.lazyViewModel
 import com.squareup.picasso.Picasso
 import com.squareup.picasso.Target
-import javax.inject.Inject
 
 /**
  * @author Pawel Karczewski <pawel.karczewski at byoutline.com> on 2015-01-03
  */
 class RewardsListActivity : KickMaterialBaseActivity() {
 
-    @Inject
-    lateinit var viewModel: RewardListViewModel
+    private val viewModel by lazyViewModel(RewardListViewModel::class)
 
     private lateinit var rewardsListRv: RecyclerView
     private lateinit var project: ProjectDetails
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        KickMaterialApp.component.inject(this)
         val binding = DataBindingUtil.setContentView<FragmentRewardsListBinding>(this, R.layout.fragment_rewards_list)
         binding.model = viewModel
         rewardsListRv = binding.categoriesRv

--- a/app/src/main/java/com/byoutline/kickmaterial/features/search/SearchListFragment.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/features/search/SearchListFragment.kt
@@ -18,22 +18,20 @@ import com.byoutline.kickmaterial.utils.KickMaterialFragment
 import com.byoutline.kickmaterial.utils.LUtils
 import com.byoutline.kickmaterial.views.EndlessRecyclerView
 import com.byoutline.secretsauce.activities.hideKeyboard
-import javax.inject.Inject
+import com.byoutline.secretsauce.di.inflateAndSetViewModel
+import com.byoutline.secretsauce.di.lazyViewModelWithAutoLifecycle
 
 class SearchListFragment : KickMaterialFragment(), ProjectClickListener, EndlessRecyclerView.EndlessScrollListener {
 
     private lateinit var projectListRv: EndlessRecyclerView
 
-    @Inject
-    lateinit var viewModel: SearchViewModel
+    val viewModel: SearchViewModel by lazyViewModelWithAutoLifecycle(this, SearchViewModel::class)
 
     private var searchView: SearchView? = null
     private var restoredSearchQuery: CharSequence = ""
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val binding = FragmentSearchResultsBinding.inflate(inflater, container, false)
-        KickMaterialApp.component.inject(this)
-        binding.viewModel = viewModel
+        val binding: FragmentSearchResultsBinding = inflateAndSetViewModel(inflater, container, R.layout.fragment_search_results, viewModel)
         projectListRv = binding.searchRecyclerView
 
         setHasOptionsMenu(true)
@@ -49,7 +47,6 @@ class SearchListFragment : KickMaterialFragment(), ProjectClickListener, Endless
         super.onResume()
         restoreDefaultScreenLook()
         hostActivity?.setToolbarAlpha(1f)
-        viewModel.attachViewUntilPause(this)
     }
 
     private fun setUpAdapters() {

--- a/app/src/main/java/com/byoutline/kickmaterial/features/selectcategory/CategoriesListActivity.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/features/selectcategory/CategoriesListActivity.kt
@@ -18,18 +18,14 @@ import android.support.v4.view.animation.FastOutSlowInInterpolator
 import android.view.View
 import android.view.ViewAnimationUtils
 import android.view.animation.OvershootInterpolator
-import com.byoutline.kickmaterial.KickMaterialApp
 import com.byoutline.kickmaterial.R
 import com.byoutline.kickmaterial.databinding.ActivityCategoryListBinding
 import com.byoutline.kickmaterial.model.Category
-import com.byoutline.kickmaterial.model.DiscoverQuery
-import com.byoutline.kickmaterial.model.DiscoverResponse
 import com.byoutline.kickmaterial.utils.ContainerTranslationScrollListener
 import com.byoutline.kickmaterial.utils.KickMaterialBaseActivity
 import com.byoutline.kickmaterial.utils.LUtils
-import com.byoutline.observablecachedfield.ObservableCachedFieldWithArg
+import com.byoutline.secretsauce.di.lazyViewModelWithAutoLifecycle
 import com.byoutline.secretsauce.utils.ViewUtils
-import javax.inject.Inject
 
 
 /**
@@ -37,10 +33,7 @@ import javax.inject.Inject
  */
 class CategoriesListActivity : KickMaterialBaseActivity(), CategoryClickListener {
 
-    @Inject
-    lateinit var discoverField: ObservableCachedFieldWithArg<DiscoverResponse, DiscoverQuery>
-    @Inject
-    lateinit var viewModel: CategoriesListViewModel
+    private val viewModel by lazyViewModelWithAutoLifecycle(this, CategoriesListViewModel::class)
 
     private var revealAnimation: Animator? = null
     private var category: Category? = null
@@ -54,7 +47,6 @@ class CategoriesListActivity : KickMaterialBaseActivity(), CategoryClickListener
         binding = DataBindingUtil.setContentView(this, R.layout.activity_category_list)
         category = intent.extras.getParcelable(ARG_CATEGORY)
 
-        KickMaterialApp.component.inject(this)
         setUpAdapters()
         setUpListeners()
         launchPostTransitionAnimations()
@@ -104,7 +96,6 @@ class CategoriesListActivity : KickMaterialBaseActivity(), CategoryClickListener
 
     public override fun onResume() {
         super.onResume()
-        viewModel.attachViewUntilPause(this)
         showToolbar(false, false)
     }
 
@@ -140,7 +131,7 @@ class CategoriesListActivity : KickMaterialBaseActivity(), CategoryClickListener
     private fun categoryClicked(category: Category) {
         animateCategoryColor(category)
         // start loading data from API during animation
-        discoverField.postValue(DiscoverQuery.getDiscoverQuery(category, 1))
+        viewModel.preloadCategory(category)
     }
 
 

--- a/app/src/main/java/com/byoutline/kickmaterial/features/selectcategory/CategoriesListViewModel.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/features/selectcategory/CategoriesListViewModel.kt
@@ -4,25 +4,24 @@ import android.databinding.ObservableArrayList
 import android.view.View
 import com.byoutline.kickmaterial.BR
 import com.byoutline.kickmaterial.R
-import com.byoutline.kickmaterial.dagger.GlobalScope
 import com.byoutline.kickmaterial.model.Category
-import com.byoutline.secretsauce.rx.invokeOnAPause
+import com.byoutline.kickmaterial.model.DiscoverQuery
+import com.byoutline.kickmaterial.model.DiscoverResponse
+import com.byoutline.observablecachedfield.ObservableCachedFieldWithArg
+import com.byoutline.secretsauce.di.AttachableViewModel
 import me.tatarka.bindingcollectionadapter2.ItemBinding
-import javax.inject.Inject
 
-
-@GlobalScope
-class CategoriesListViewModel @Inject
-constructor() {
+class CategoriesListViewModel(
+        private val discoverField: ObservableCachedFieldWithArg<DiscoverResponse, DiscoverQuery>
+) : AttachableViewModel<CategoryClickListener>() {
     val items: ObservableArrayList<Category> = DataManager.categoriesList
     val itemBinding: ItemBinding<Category>
-    private var clickListener: CategoryClickListener? = null
 
     init {
         itemBinding = ItemBinding.of<Category>(BR.categoryItem, R.layout.category_list_item)
                 .bindExtra(BR.categoryClickListener, object : CategoryClickListener {
                     override fun categoryClicked(view: View, category: Category) {
-                        clickListener?.categoryClicked(view, category)
+                        this@CategoriesListViewModel.view?.categoryClicked(view, category)
                     }
                 })
     }
@@ -31,8 +30,7 @@ constructor() {
         items[0].setBgColor(color)
     }
 
-    fun attachViewUntilPause(activity: CategoriesListActivity) {
-        this.clickListener = activity
-        activity.invokeOnAPause { this.clickListener = null }
+    fun preloadCategory(category: Category) {
+        discoverField.postValue(DiscoverQuery.getDiscoverQuery(category, 1))
     }
 }

--- a/app/src/main/java/com/byoutline/kickmaterial/utils/KickMaterialBaseActivity.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/utils/KickMaterialBaseActivity.kt
@@ -7,8 +7,6 @@ import android.content.pm.ActivityInfo
 import android.os.Build
 import android.os.Bundle
 import android.support.annotation.CallSuper
-import android.support.annotation.CheckResult
-import android.support.annotation.NonNull
 import android.support.annotation.StringRes
 import android.support.v4.view.ViewCompat
 import android.support.v7.app.AppCompatActivity
@@ -22,21 +20,13 @@ import android.view.animation.DecelerateInterpolator
 import android.widget.TextView
 import com.byoutline.kickmaterial.R
 import com.byoutline.secretsauce.utils.ViewUtils
-import com.trello.rxlifecycle2.LifecycleProvider
-import com.trello.rxlifecycle2.LifecycleTransformer
-import com.trello.rxlifecycle2.RxLifecycle
-import com.trello.rxlifecycle2.android.ActivityEvent
-import com.trello.rxlifecycle2.android.RxLifecycleAndroid
-import io.reactivex.Observable
-import io.reactivex.subjects.BehaviorSubject
 import java.util.*
 
 
 /**
  * @author Pawel Karczewski <pawel.karczewski at byoutline.com> on 2015-01-03
  */
-abstract class KickMaterialBaseActivity : AppCompatActivity(), KickMaterialFragment.HostActivity,
-        LifecycleProvider<ActivityEvent> {
+abstract class KickMaterialBaseActivity : AppCompatActivity(), KickMaterialFragment.HostActivity {
     private var toolbarAutoHideSensitivity = 0
     private var toolbarAutoHideMinY = 0
     private var toolbarAutoHideSignal = 0
@@ -48,7 +38,6 @@ abstract class KickMaterialBaseActivity : AppCompatActivity(), KickMaterialFragm
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         blockOrientationOnBuggedAndroidVersions()
-        lifecycleSubject.onNext(ActivityEvent.CREATE)
     }
 
     override fun onPostCreate(savedInstanceState: Bundle?) {
@@ -203,49 +192,5 @@ abstract class KickMaterialBaseActivity : AppCompatActivity(), KickMaterialFragm
             options = ActivityOptions.makeSceneTransitionAnimation(activity, *arr).toBundle()
             return options
         }
-    }
-
-    // RxActivity:
-    private val lifecycleSubject = BehaviorSubject.create<ActivityEvent>()
-
-    @CheckResult
-    override fun lifecycle(): Observable<ActivityEvent> = lifecycleSubject.hide()
-
-    @CheckResult
-    override fun <T> bindUntilEvent(event: ActivityEvent): LifecycleTransformer<T>
-            = RxLifecycle.bindUntilEvent(lifecycleSubject, event)
-
-    @NonNull
-    @CheckResult
-    override fun <T> bindToLifecycle(): LifecycleTransformer<T> = RxLifecycleAndroid.bindActivity(lifecycleSubject)
-
-    @CallSuper
-    override fun onStart() {
-        super.onStart()
-        lifecycleSubject.onNext(ActivityEvent.START)
-    }
-
-    @CallSuper
-    override fun onResume() {
-        super.onResume()
-        lifecycleSubject.onNext(ActivityEvent.RESUME)
-    }
-
-    @CallSuper
-    override fun onPause() {
-        lifecycleSubject.onNext(ActivityEvent.PAUSE)
-        super.onPause()
-    }
-
-    @CallSuper
-    override fun onStop() {
-        lifecycleSubject.onNext(ActivityEvent.STOP)
-        super.onStop()
-    }
-
-    @CallSuper
-    override fun onDestroy() {
-        lifecycleSubject.onNext(ActivityEvent.DESTROY)
-        super.onDestroy()
     }
 }

--- a/app/src/main/java/com/byoutline/kickmaterial/utils/KickMaterialFragment.kt
+++ b/app/src/main/java/com/byoutline/kickmaterial/utils/KickMaterialFragment.kt
@@ -2,12 +2,12 @@ package com.byoutline.kickmaterial.utils
 
 import android.app.Activity
 import android.support.annotation.StringRes
+import android.support.v4.app.Fragment
 import android.support.v7.widget.RecyclerView
 import com.byoutline.secretsauce.activities.hideKeyboard
-import com.trello.rxlifecycle2.components.support.RxFragment
 
 
-abstract class KickMaterialFragment : RxFragment() {
+abstract class KickMaterialFragment : Fragment() {
 
     protected var hostActivity: HostActivity? = null
 
@@ -18,10 +18,10 @@ abstract class KickMaterialFragment : RxFragment() {
     override fun onAttach(activity: Activity?) {
         super.onAttach(activity)
         try {
-            hostActivity = activity as? HostActivity?
+            hostActivity = activity as HostActivity
         } catch (e: ClassCastException) {
-            throw IllegalStateException("${activity!!.javaClass.simpleName} does not implement " +
-                    "${ HostActivity::class.java.simpleName} interface")
+            throw IllegalStateException("${activity?.javaClass?.simpleName} does not implement " +
+                    "${HostActivity::class.java.simpleName} interface")
         }
     }
 

--- a/circle.yml
+++ b/circle.yml
@@ -33,6 +33,6 @@ dependencies:
 
 test:
   pre:
-    - case $CIRCLE_NODE_INDEX in 0) ./gradlew assembleDebug ;; 1) ./gradlew check lint ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) ./gradlew assembleDebug ;; 1) ./gradlew check && ./gradlew lint ;; esac:
         parallel: true
 


### PR DESCRIPTION
Makes modules life shorter via usage of AndroidModules from Dagger and Lifecycle architecture components. 

* Use viewModels scoped to Activity/Fragment
* Remove RxLifecycle
* Rename: GlobalModule -> AppModule
* GlobalScope -> Singleton 
